### PR TITLE
Avoid error when "link" feature is not present in the toolbar

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -216,7 +216,7 @@
     var node = this._sel.focusNode
       , effects = this._effectNode(node)
       , menu = this._menu
-      , highlight;
+      , highlight, linkinput;
 
     // remove all highlights
     [].slice.call(menu.querySelectorAll('.active')).forEach(function(el) {
@@ -224,7 +224,9 @@
     });
 
     // display link input
-    menu.querySelector('input').style.display = 'none';
+    linkinput = menu.querySelector('input');
+    if (linkinput) linkinput.style.display = 'none';
+
 
     highlight = function(str) {
       var selector = '.icon-' + str


### PR DESCRIPTION
Not try to updates styles of a non-present input when "createlink" is not present in the tools list.
