### PR TITLE
fixed method mis-spelling in the index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
       pen.rebuild();
     } else {
       this.classList.add('disabled');
-      pen.destory();
+      pen.destroy();
     }
   });
 


### PR DESCRIPTION
Hi,

The example (index.html) had a incorrectly spelt method for removing the editor
(Tripped me up as I copied the example for my own prototype so might catch other)

cheers

Andrew
