### PR TITLE
Fixed disappearing content in markdown mode.

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -48,12 +48,24 @@
 
   // exec command
   covertor.action = function(pen, cmd) {
+    var trimContent = function (length) {
+      var node = pen._sel.focusNode; 
+      node.textContent = node.textContent.slice(length); 
+    };
+    var defer = function(func){
+      var argv = Array.prototype.slice.call(arguments, 1);
+      return setTimeout(function(){ return func.apply(null, argv); }, 1);
+    };
 
     // only apply effect at line start
     if(pen._sel.focusOffset > cmd[1]) return;
 
-    var node = pen._sel.focusNode;
-    node.textContent = node.textContent.slice(cmd[1]);
+    if (cmd[0] === 'inserthorizontalrule') {
+      trimContent(cmd[1]);
+    } else {
+      defer(trimContent, cmd[1]); 
+    }
+    
     pen._actions(cmd[0]);
     pen.nostyle();
   };


### PR DESCRIPTION
This fixes the issue of disappearing content, while using the markdown features

Replication steps:
1. Put your cursor at the end of the second paragraph in index.html,
after "... an empty value to the input field."
2. Press enter, and then add some markdown i.e. "1. " or "# "
