### PR TITLE
Add markdown hints

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
   #mode{color:#1abf89;;cursor:pointer;}
   #mode.disabled{color:#666;}
   #mode:before{content: '\e813';}
+  #hinted{color:#1abf89;cursor:pointer;}
+  #hinted.disabled{color:#666;}
+  #hinted:before{content: '\e816';}
+
   #fork{position:fixed;right:0;top:0;}
   </style>
   <link rel="stylesheet" href="src/pen.css" />
@@ -22,6 +26,7 @@
 
 <div id="toolbar">
   <span id="mode" class="icon-mode"></span>
+  <span id="hinted" class="icon-pre disabled" title="Toggle Markdown Hints"></span>
 </div>
 
 <div data-toggle="pen" placeholder="im a placeholder">
@@ -77,6 +82,18 @@
     }
   });
 
+  // toggle editor mode
+  document.querySelector('#hinted').addEventListener('click', function() {
+    var pen = document.querySelector('.pen')
+
+    if(pen.classList.contains('hinted')) {
+      pen.classList.remove('hinted');
+      this.classList.add('disabled');
+    } else {
+      pen.classList.add('hinted');
+      this.classList.remove('disabled');
+    }
+  });
 </script>
 </body>
 </html>

--- a/src/pen.css
+++ b/src/pen.css
@@ -102,3 +102,59 @@
 .pen-menu .icon-inserthorizontalrule:before { content: '\e818'; } /* '' */
 .pen-menu .icon-pin:before { content: '\e812'; } /* '' */
 .pen-menu .icon-createlink:before { content: '\e810'; } /* '' */
+
+.pen {
+  position: relative;
+}
+.pen.hinted h1:before,
+.pen.hinted h2:before,
+.pen.hinted h3:before,
+.pen.hinted h4:before,
+.pen.hinted h5:before,
+.pen.hinted h6:before,
+.pen.hinted blockquote:before,
+.pen.hinted hr:before {
+  color: #eee;
+  position: absolute;
+  right: 100%;
+  white-space: nowrap;
+  padding-right: 10px;
+}
+.pen.hinted blockquote {  border-left: 0; margin-left: 0; padding-left: 0; }
+.pen.hinted blockquote:before {
+  color: #1abf89;
+  content: ">";
+  font-weight: bold;
+  vertical-align: center;
+}
+.pen.hinted h1:before { content: "#";}
+.pen.hinted h2:before { content: "##";}
+.pen.hinted h3:before { content: "###";}
+.pen.hinted h4:before { content: "####";}
+.pen.hinted h5:before { content: "#####";}
+.pen.hinted h6:before { content: "######";}
+.pen.hinted hr:before { content: "﹘﹘﹘"; line-height: 1.2; vertical-align: bottom; }
+
+.pen.hinted pre:before, .pen.hinted pre:after {
+  content: "```";
+  display: block;
+  color: #ccc;
+}
+
+.pen.hinted ul { list-style: none; }
+.pen.hinted ul li:before {
+  content: "*";
+  color: #999;
+  line-height: 1;
+  vertical-align: bottom;
+  margin-left: -1.2em;
+  display: inline-block;
+  width: 1.2em;
+}
+
+.pen.hinted b:before, .pen.hinted b:after { content: "**"; color: #eee; font-weight: normal; }
+.pen.hinted i:before, .pen.hinted i:after { content: "*"; color: #eee; }
+
+.pen.hinted a { text-decoration: none; }
+.pen.hinted a:before {content: "["; color: #ddd; }
+.pen.hinted a:after { content: "](" attr(href) ")"; color: #ddd; }


### PR DESCRIPTION
This adds a mode that shows hints of the markdown that was used to create the tags. This is a really useful way to teach people markdown.

![markdown-hints](https://f.cloud.github.com/assets/173/2119029/fd684da0-913a-11e3-9dec-16fc4da8303e.gif)

It is all just generated with `:before` and `:after` selectors on the elements.
