### PR TITLE
Reset link input value on highlight

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -235,8 +235,12 @@
       el.classList.remove('active');
     });
 
-    // display link input if createlink enabled
-    if (linkInput) linkInput.style.display = 'none';
+    if (linkInput) {
+      // display link input if createlink enabled
+      linkInput.style.display = 'none';
+      // reset link input value
+      linkInput.value = '';
+    }
 
     highlight = function(str) {
       var selector = '.icon-' + str


### PR DESCRIPTION
When a user creates a link and then goes to create another, the url from the first link is displayed as the default value in the input for the second link. This commit causes the link input value to be reset so when the user goes to create a second link they will have a blank input.
