### PR TITLE
Avoid document overflow

### DIFF
--- a/src/pen.css
+++ b/src/pen.css
@@ -39,7 +39,7 @@
 .pen-menu{white-space:nowrap;box-shadow:1px 2px 3px -2px #222;background:#333;background-image:linear-gradient(to bottom, #222, #333);opacity:0.9;position:fixed;height:36px;border:1px solid #333;border-radius:3px;display:none;z-index:1000;}
 .pen-menu:after {top:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none;}
 .pen-menu:after {border-color:rgba(51, 51, 51, 0);border-top-color:#333;border-width:6px;left:50%;margin-left:-6px;}
-.pen-menu-below:after {top: -12px; display:block; -moz-transform: rotate(180deg); -webkit-transform: rotate(180deg); -ms-transform: rotate(180deg); -o-transform: rotate(180deg); transform: rotate(180deg);}
+.pen-menu-below:after {top: -11px; display:block; -moz-transform: rotate(180deg); -webkit-transform: rotate(180deg); -ms-transform: rotate(180deg); -o-transform: rotate(180deg); transform: rotate(180deg);}
 .pen-icon{font:normal 900 16px/40px Georgia serif;min-width:20px;display:inline-block;padding:0 10px;height:36px;overflow:hidden;color:#fff;text-align:center;cursor:pointer;-moz-user-select:none;-webkit-user-select:none;-ms-user-select:none;user-select:none;}
 .pen-icon:first-of-type{border-top-left-radius:3px;border-bottom-left-radius:3px;}
 .pen-icon:last-of-type{border-top-right-radius:3px;border-bottom-right-radius:3px;}

--- a/src/pen.js
+++ b/src/pen.js
@@ -357,11 +357,14 @@
     // check to see if menu has over-extended its bounding box. if it has,
     // 1) apply a new class if overflowed on top;
     // 2) apply a new rule if overflowed on the left
+    if(stylesheet.cssRules.length > 0) {
+      stylesheet.deleteRule(0);
+    }
     if(menuOffset.x < 0) {
       menuOffset.x = 0;
-      stylesheet.addRule('.pen-menu:after', 'left: ' + left + 'px');
+      stylesheet.insertRule('.pen-menu:after { left: ' + left + 'px; }',0);
     } else {
-      stylesheet.addRule('.pen-menu:after', 'left: 50%');
+      stylesheet.insertRule('.pen-menu:after { left: 50%; }',0);
     }
     if(menuOffset.y < 0) {
       menu.classList.toggle('pen-menu-below', true);


### PR DESCRIPTION
Added some logic to avoid the menu being outside of the window's bounding box.

Screenshots demonstrating feature:
![screen shot 2014-07-15 at 8 52 50 pm](https://cloud.githubusercontent.com/assets/3921894/3594122/6f010e1e-0c94-11e4-97f3-b56b037ae82e.png)
![screen shot 2014-07-15 at 8 52 58 pm](https://cloud.githubusercontent.com/assets/3921894/3594123/6f03198e-0c94-11e4-96c5-172c99817365.png)
![screen shot 2014-07-15 at 8 53 06 pm](https://cloud.githubusercontent.com/assets/3921894/3594124/6f06536a-0c94-11e4-85bf-ed16609020c8.png)
