### PR TITLE
correct the path used in `main` attribute in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "homepage": "https://github.com/sofish/pen",
   "description": "enjoy live editing(+markdown)",
-  "main": "pen.js",
+  "main": "src/pen.js",
   "keywords": [
     "editor",
     "wysiwyg",


### PR DESCRIPTION
`bower.json`中main声明和实际路径不符合，使用wiredep自动向html中添加依赖时候，会找不到pen.js文件
