### PR TITLE
处理插入代码时出现undefined的情况

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -135,7 +135,7 @@
   }
 
   function commandWrap(ctx, tag, value) {
-    value = '<' + tag + '>' + value + '</' + tag + '>';
+    value = '<' + tag + '>' + (value||'') + '</' + tag + '>';
     return commandOverall(ctx, 'insertHTML', value);
   }
 


### PR DESCRIPTION
双击某个地方选中一个单词，点击code，会出现undefined字样。不确定是否是意料中的行为，或者也有可能是前面没处理好导致undefined出现
