### PR TITLE
Add stylesheet to main in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,10 @@
   "version": "0.0.2",
   "homepage": "https://github.com/sofish/pen",
   "description": "enjoy live editing(+markdown)",
-  "main": "src/pen.js",
+  "main": [
+    "src/pen.js",
+    "src/pen.css"
+  ],
   "keywords": [
     "editor",
     "wysiwyg",


### PR DESCRIPTION
This lets packages like wiredep automatically inject both the CSS and JS for Pen as dependencies in our applications.