### PR TITLE
修复 enter 键问题 和 支持固定 toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,24 @@
   <span id="hinted" class="icon-pre disabled" title="Toggle Markdown Hints"></span>
 </div>
 
+<!-- <div id="custom-toolbar" class="pen-menu pen-menu" style="display: block; top: 20px; left: 10px;">
+  <i class="pen-icon icon-insertimage" data-action="insertimage"></i>
+  <i class="pen-icon icon-blockquote" data-action="blockquote"></i>
+  <i class="pen-icon icon-h2" data-action="h2"></i>
+  <i class="pen-icon icon-h3" data-action="h3"></i>
+  <i class="pen-icon icon-p active" data-action="p"></i>
+  <i class="pen-icon icon-code" data-action="code"></i>
+  <i class="pen-icon icon-insertorderedlist" data-action="insertorderedlist"></i>
+  <i class="pen-icon icon-insertunorderedlist" data-action="insertunorderedlist"></i>
+  <i class="pen-icon icon-inserthorizontalrule" data-action="inserthorizontalrule"></i>
+  <i class="pen-icon icon-indent" data-action="indent"></i>
+  <i class="pen-icon icon-outdent" data-action="outdent"></i>
+  <i class="pen-icon icon-bold" data-action="bold"></i>
+  <i class="pen-icon icon-italic" data-action="italic"></i>
+  <i class="pen-icon icon-underline" data-action="underline"></i>
+  <i class="pen-icon icon-createlink" data-action="createlink"></i>
+</div> -->
+
 <div data-toggle="pen" data-placeholder="im a placeholder">
   <h2>Enjoy live editing (+markdown)</h2>
 
@@ -81,6 +99,7 @@
 
   // config
   var options = {
+    // toolbar: document.getElementById('custom-toolbar'),
     editor: document.querySelector('[data-toggle="pen"]'),
     debug: true,
     list: [

--- a/src/pen.css
+++ b/src/pen.css
@@ -39,7 +39,7 @@
   background: transparent;
   background-image: none;
 }
-
+.pen-menu { min-width: 320px; }
 .pen-menu, .pen-input{font-size:14px;line-height:1;}
 .pen-menu{white-space:nowrap;box-shadow:1px 2px 3px -2px #222;background:#333;background-image:linear-gradient(to bottom, #222, #333);opacity:0.9;position:fixed;height:36px;border:1px solid #333;border-radius:3px;display:none;z-index:1000;}
 .pen-menu:after {top:100%;border:solid transparent;content:" ";height:0;width:0;position:absolute;pointer-events:none;}
@@ -82,7 +82,6 @@
   line-height: 1em;
   margin-left: .2em;
 }
-
 .pen-menu .icon-location:before { content: '\e815'; } /* '' */
 .pen-menu .icon-fit:before { content: '\e80f'; } /* '' */
 .pen-menu .icon-bold:before { content: '\e805'; } /* '' */
@@ -117,7 +116,6 @@
 .pen-menu .icon-h6:before { content: 'H6'; }
 .pen-menu .icon-p:before { content: 'P'; }
 .pen-menu .icon-insertimage:before { width:1.8em;margin:0;position:relative;top:-2px;content:'IMG';font-size:12px;border:1px solid #fff;padding:2px;border-radius:2px; }
-
 .pen {
   position: relative;
 }

--- a/src/pen.js
+++ b/src/pen.js
@@ -1,5 +1,5 @@
 /*! Licensed under MIT, https://github.com/sofish/pen */
-;(function(root, doc) {
+(function(root, doc) {
 
   var Pen, debugMode, selection, utils = {};
   var toString = Object.prototype.toString;
@@ -342,10 +342,10 @@
   }
 
   function removeListener(ctx, target, type, listener) {
-    var events = events = ctx._events[type];
+    var events = ctx._events[type];
     if (!events) {
       var _index = ctx._eventTargets.indexOf(target);
-      if (_index >= 0) events = ctx._eventsCache[_index][type]
+      if (_index >= 0) events = ctx._eventsCache[_index][type];
     }
     if (!events) return ctx;
     var index = events.indexOf(listener);
@@ -525,7 +525,7 @@
   };
 
   Pen.prototype.getContent = function() {
-    return trim(this.config.editor.innerHTML);
+    return this.isEmpty() ?  '' : trim(this.config.editor.innerHTML);
   };
 
   Pen.prototype.setContent = function(html) {


### PR DESCRIPTION
关于 enter 键问题，原来确实有很严重的 bug。修复后，比如在 blockquote 中按 enter 键，理想状况应该是留在同一个 blockquote 中，如果当前行为空再按 enter 键，则退出 blockquote。firefox 和 chrome 的 enter 行为不一致，这里进行了 hack 修正。（测试 Medium Editor 并没有解决这个问题~）

另一个较大的调整是 支持自定义的 toolbar，即在option 中传入自定义的 toolbar，这个需求主要是为了实现固定的 toolbar ，同时又不影响 link 和 image 的 浮动输入框。

实例效果：
![qq20150203-1 2x](https://cloud.githubusercontent.com/assets/863754/6021901/0b92abb2-abf4-11e4-96c0-6389085923c5.png)

![qq20150204-1](https://cloud.githubusercontent.com/assets/863754/6033073/f216bd4c-ac4b-11e4-82d3-c26db816944a.png)
