### PR TITLE
Fix double click visual discontinuity.

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -702,6 +702,9 @@
       , menu = this._menu
       , menuOffset = {x: 0, y: 0}
       , stylesheet = this._stylesheet;
+    
+    // fixes some browser double click visual discontinuity
+    // if the offset has no width or height it should not be used
     if (offset.width === 0 && offset.height === 0) return this;
 
     // store the stylesheet used for positioning the menu horizontally

--- a/src/pen.js
+++ b/src/pen.js
@@ -702,6 +702,7 @@
       , menu = this._menu
       , menuOffset = {x: 0, y: 0}
       , stylesheet = this._stylesheet;
+    if (offset.width === 0 && offset.height === 0) return this;
 
     // store the stylesheet used for positioning the menu horizontally
     if (this._stylesheet === undefined) {


### PR DESCRIPTION
In some browsers the toolbar briefly flashes in the top left corner before being correctly placed when the user double clicks. This is because the range rectangle has all of its values set to 0. Here we detect if the offset defined has a width and height of 0, if this is so we can safely assume the toolbar should not yet be rendered. Works as expected.