### PR TITLE
add capability to make toolbar buttons with child nodes

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -259,7 +259,11 @@
 
     // toggle toolbar on key select
     addListener(ctx, toolbar, 'click', function(e) {
-      var action = e.target.getAttribute('data-action');
+      var node = e.target, action;
+
+      while (node != toolbar && !(action = node.getAttribute('data-action'))) {
+        node = node.parentNode;
+      }
 
       if (!action) return;
       if (!/(?:createlink)|(?:insertimage)/.test(action)) return menuApply(action);

--- a/src/pen.js
+++ b/src/pen.js
@@ -261,7 +261,7 @@
     addListener(ctx, toolbar, 'click', function(e) {
       var node = e.target, action;
 
-      while (node != toolbar && !(action = node.getAttribute('data-action'))) {
+      while (node !== toolbar && !(action = node.getAttribute('data-action'))) {
         node = node.parentNode;
       }
 


### PR DESCRIPTION
If button have a child nodes and user clicks on one of them, then listener do not work as expected. It just stops because child nodes don't have a `data-action` attribute.
So, I added ability to make buttons with child node infinite nesting.