### PR TITLE
fix for jshint: missing hasOwnProperty in for-in loop

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -815,7 +815,8 @@
           .replace(/<([uo])l\b[^>]*>(.*?)<\/\1l>/ig, '$2'); // remove ul/ol
 
     for(var p in regs) {
-      html = html.replace.apply(html, regs[p]);
+      if (regs.hasOwnProperty(p))
+        html = html.replace.apply(html, regs[p]);
     }
     return html.replace(/\*{5}/g, '**');
   };


### PR DESCRIPTION
```
D:\test\pen>grunt
Running "jshint:files" (jshint) task
Linting src/pen.js ...ERROR
[L817:C5] W089: The body of a for in should be wrapped in an if statement to filter unwanted properties from the prototype.
    for(var p in regs) {

Warning: Task "jshint:files" failed. Use --force to continue.

Aborted due to warnings.
```

And the test passed ;) would be happy if merged