### PR TITLE
Stop leading space after entering Markdown

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -43,7 +43,7 @@
       if (cmd) {
         // prevents leading space after executing command
         e.preventDefault();
-        return this.valid(cmd);
+        return cmd;
       }
     }
 

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -34,10 +34,17 @@
     var code = e.keyCode || e.which;
 
     // when `space` is pressed
-    if(code === 32) {
-      var cmd = this.stack.join('');
-      this.stack.length = 0;
-      return this.valid(cmd);
+    if (code === 32) {
+      var markdownSyntax = this.stack.join('');
+      // reset stack
+      this.stack = [];
+
+      var cmd = this.valid(markdownSyntax);
+      if (cmd) {
+        // prevents leading space after executing command
+        e.preventDefault();
+        return this.valid(cmd);
+      }
     }
 
     // make cmd


### PR DESCRIPTION
Before, typing `#`, `space`, then `hello` results in an `<h1>` with a leading space (`<h1> hello</h1>`).

This commit stops the insertion of the space if markdown syntax is detected.