### PR TITLE
Add title hints to Pen toolbar icons

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -146,9 +146,12 @@
     ctx._toolbar = ctx.config.toolbar;
     if (!ctx._toolbar) {
       var toolList = ctx.config.list;
-      utils.forEach(toolList, function (name) {
+      utils.forEach(toolList, function (listname) {
+        var parts = listname.split('|'),
+            name = parts[0] || listname,
+            tooltip = parts[1] || '';
         var klass = 'pen-icon icon-' + name;
-        icons += '<i class="' + klass + '" data-action="' + name + '"></i>';
+        icons += '<i class="' + klass + '" data-action="' + name + '" title="' + tooltip + '"></i>';
       }, true);
       if (toolList.indexOf('createlink') >= 0 || toolList.indexOf('createlink') >= 0)
         icons += inputStr;


### PR DESCRIPTION
This change adds a title attribute to each toolbar icon so that users can get a better idea what that icon will do. The title attribute is included in the options.list, separated from the command name by a vertical bar. 
    list: [
            'blockquote|Blockquote',
            'h3|Heading 3',
            'h4|Heading 4',
            'code|Code',
            'insertunorderedlist|Unordered list',
            'bold|Bold',
            'italic|Italic',
            'createlink|Hyperlink',
            'insertimage|Image'
        ],