### PR TITLE
Optionally add titles to icons

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,14 +94,32 @@ You can set `options.list` to an `Array`, add the following strings to make your
 - `underline`: wrap the text selection in a `u` tag
 - `createlink`: insert link to the text selection
 - `inserthorizontalrule`: insert a `hr` tag
+- `insertimage`: insert an image (`img`) tag
 
-#### 2.5 Prevent unsafe page redirect
+#### 2.5 Add tooltips to the toolbar icons
+
+You can set `options.titles` to an object with properties that match the toolbar actions. The value of each property
+will be used as the title attribute on the icon. Most browsers will display the title attribute as a tooltip when
+the mouse hovers over the icon.
+
+```js
+options.title = {
+    'blockquote': 'Blockquote'
+    'createlink': 'Hyperlink'
+    'insertimage': 'Image'
+}
+```
+
+If you are using Bootstrap or jQueryUI, you can standardize the tooltip style by adding `$('i.pen-icon').tooltip()`
+to your JavaScript.
+
+#### 2.6 Prevent unsafe page redirect
 
 By default, Pen will prevent unsafe page redirect when editing, to shut down it, specific `options.stay` to `false`.
 
 __NOTE:__ if `defaults.debug` is set to `true` and `default.stay` is not set: `defaults.stay == !defaults.debug`.
 
-#### 2.6 Disable and Re-enable editor
+#### 2.7 Disable and Re-enable editor
 
 You can disable the pen editor by call `destroy()` method of the `var pen = new Pen(options)` object. like:
 
@@ -117,7 +135,7 @@ And, there's a corresponding method called `rebuild()` to re-enable the editor:
 pen.rebuild(); // return itself
 ```
 
-#### 2.7 Export content as markdown
+#### 2.8 Export content as markdown
 
 It's an experimental feature
 

--- a/src/pen.js
+++ b/src/pen.js
@@ -88,6 +88,7 @@
         'blockquote', 'h2', 'h3', 'p', 'code', 'insertorderedlist', 'insertunorderedlist', 'inserthorizontalrule',
         'indent', 'outdent', 'bold', 'italic', 'underline', 'createlink', 'insertimage'
       ],
+      titles: {},
       cleanAttrs: ['id', 'class', 'style', 'name'],
       cleanTags: ['script']
     };
@@ -148,7 +149,8 @@
       var toolList = ctx.config.list;
       utils.forEach(toolList, function (name) {
         var klass = 'pen-icon icon-' + name;
-        icons += '<i class="' + klass + '" data-action="' + name + '"></i>';
+        var title = ctx.config.titles[name] || '';
+        icons += '<i class="' + klass + '" data-action="' + name + '" title="' + title + '"></i>';
       }, true);
       if (toolList.indexOf('createlink') >= 0 || toolList.indexOf('createlink') >= 0)
         icons += inputStr;


### PR DESCRIPTION
Allows users to define a title for each icon on the toolbar. The title will show as a tooltip when the mouse is over the icon.

Titles are configured through a "titles" object in the "options" object. Use the command name for the property and the title as its value:

    options = {
        titles: {
            blockquote: 'Blockquote',
            bold: 'Bold',
            italic: 'Italic',
            createlink: 'Hyperlink',
            insertimage: 'Image',
            ...
        },
        ...
    }