### PR TITLE
fixed typo in toolbar initialization 

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -152,7 +152,7 @@
         var title = ctx.config.titles[name] || '';
         icons += '<i class="' + klass + '" data-action="' + name + '" title="' + title + '"></i>';
       }, true);
-      if (toolList.indexOf('createlink') >= 0 || toolList.indexOf('createlink') >= 0)
+      if (toolList.indexOf('createlink') >= 0 || toolList.indexOf('insertimage') >= 0)
         icons += inputStr;
     } else if (ctx._toolbar.querySelectorAll('[data-action=createlink]').length ||
       ctx._toolbar.querySelectorAll('[data-action=insertimage]').length) {


### PR DESCRIPTION
fixed typo in toolbar initialization:
(insertimage used without create… link was not showing the input for URL)