### PR TITLE
Input element for form integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/sofish/pen/blob/master/license.txt"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
+    "grunt": "^0.4.5",
     "grunt-contrib-jshint": "~0.7.2",
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-contrib-watch": "~0.5.3"

--- a/src/pen.js
+++ b/src/pen.js
@@ -517,12 +517,23 @@
     // stay on the page
     if (this.config.stay) this.stay(this.config);
 
+    if(this.config.input) {
+      this.addOnSubmitListener(this.config.input);
+    }
   };
 
   Pen.prototype.on = function(type, listener) {
     addListener(this, this.config.editor, type, listener);
     return this;
   };
+
+  Pen.prototype.addOnSubmitListener = function(inputElement) {
+    var form = inputElement.form;
+    var me = this;
+    form.addEventListener("submit", function() {
+      inputElement.value = me.config.editor.innerHTML;
+    });
+  }
 
   Pen.prototype.isEmpty = function(node) {
     node = node || this.config.editor;

--- a/src/pen.js
+++ b/src/pen.js
@@ -531,7 +531,7 @@
     var form = inputElement.form;
     var me = this;
     form.addEventListener("submit", function() {
-      inputElement.value = me.config.editor.innerHTML;
+      inputElement.value = me.config.saveAsMarkdown ? me.toMd(me.config.editor.innerHTML) : me.config.editor.innerHTML;
     });
   };
 


### PR DESCRIPTION
Added a config element for 'input' to make it easier to integrate with forms in a site. It is supposed to be configured the same way other such config elements use like 'editor'.