### PR TITLE
Fix for issue #170

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -512,7 +512,7 @@
     this._prevContent = this.getContent();
 
     // enable markdown covert
-    if (this.markdown) this.markdown.init(this);
+    //if (this.markdown) this.markdown.init(this);
 
     // stay on the page
     if (this.config.stay) this.stay(this.config);
@@ -782,6 +782,7 @@
     } else {
       initToolbar(this);
       initEvents(this);
+      if (this.markdown) this.markdown.init(this);
     }
     this._isDestroyed = destroy;
     this.config.editor[attr]('contenteditable', '');


### PR DESCRIPTION
Fixes an issue ( #170 ) with Chrome 52 and Firefox 47 (and potentially other browsers) where calling pen.destroy() and then pen.rebuild() causes the markdown converter's onKeypress event handler to stop handling events.