### PR TITLE
commandLink() 'this' -> 'ctx'

### DIFF
--- a/src/pen.js
+++ b/src/pen.js
@@ -143,7 +143,7 @@
   }
 
   function commandLink(ctx, tag, value) {
-    if (this.config.linksInNewWindow) {
+    if (ctx.config.linksInNewWindow) {
       value = '< a href="' + value + '" target="_blank">' + (selection.toString()) + '</a>';
       return commandOverall(ctx, 'insertHTML', value);
     } else {


### PR DESCRIPTION
commandLink() referenced 'this.config' where 'this' is undefined. Seems like it should instead be getting 'ctx.config'.